### PR TITLE
fix(agEnv): Create Mock with Clone to avoid breaking variable contents

### DIFF
--- a/scripts/tests/agEnv.Tests.ps1
+++ b/scripts/tests/agEnv.Tests.ps1
@@ -1,8 +1,24 @@
+# src: scripts/tests/agEnv.Tests.ps1
+# @(#) : agEnv.Tests.ps1 : 環境変数関連関数の機能テスト
+#
+# Copyright (c) 2023 atsushifx <atsushifx@gmail.com>
+# Released under the MIT License
+# https://opensource.org/licenses/MIT
+
+<#
+.SUMMARY
+Tests the functions in agEnv.ps1
+
+.DESCRIPTION
+Tests the functions in agEnv.ps1
+    setEnv: Set an environment variable with optional process synchronization.
+    getEnv: Retrieves the value of an environment variable.
+    removeEnv: Removes an environment variable.
+#>
 BeforeAll {
     $script = $SCRIPTROOT + '\libs\agEnv.ps1'
     . $script
 }
-
 Describe "AgEnv script functions test (agSetEnv/agGetEnv/agRemoveEnv)" {
 
     AfterEach {
@@ -41,8 +57,8 @@ Describe "AgEnv script functions test (agSetEnv/agGetEnv/agRemoveEnv)" {
 
 Describe "AgEnv protect Environment Variable tests" {
     BeforeEach {
-        $script:originalProtectedKeys = [AgEnv]::ProtectedKeys
-        [AgEnv]::ProtectedKeys = $script:originalProtectedKeys + @("<MOCK_ENV>")
+        $script:originalProtectedKeys = [AgEnv]::ProtectedKeys.Clone()
+        [AgEnv]::ProtectedKeys = $script:originalProtectedKeys + "<MOCK_ENV>"
     }
     AfterEach {
         [AgEnv]::ProtectedKeys = $script:originalProtectedKeys

--- a/scripts/tests/mkdirFromList.Tests.ps1
+++ b/scripts/tests/mkdirFromList.Tests.ps1
@@ -16,19 +16,16 @@ mkdirFromList.Tests : ディレクトリ作成テスト
 #>
 
 # --- import
-. "$SCRIPTROOT/libs/pathUtils.ps1"
 # すぐ後に関数が定義されているか確認
-
+BeforeAll {
+    . "$SCRIPTROOT/libs/pathUtils.ps1"
+}
 # --- テストメイン
 Describe "pathUtils: mkdirFromList (Dry-Run mode)" {
     # Mock Dir
     $script:mockCurrent = "C:\<Mock>\Current"
     $script:mockHome = "C:\<Mock>\Home"
     $script:originalHome = $env:USERPROFILE
-
-    BeforeAll {
-        . "$SCRIPTROOT/libs/pathUtils.ps1"
-    }
 
     BeforeEach {
         # 環境変数とGet-Locationのモック


### PR DESCRIPTION
## ✨ Overview

Fixes a unit test failure related to environment variable protection logic by ensuring correct handling of the `ProtectedKeys` array in test setup.

This change ensures that protected environment variable names are accurately recognized and cause the intended exceptions during testing.

---

## 🔧 Changes

List the key changes included in this PR:

- [x] Refactored test setup logic to properly clone `ProtectedKeys` array
- [x] Ensured isolated state in test `BeforeEach` block
- [x] Fixed test failures in `AgEnv protect Environment Variable tests`

---

## 📂 Related Issues

---

## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

Replaced direct list reference modification with `.Clone()` to prevent unwanted side-effects in subsequent tests.  
This fixes the test expectation that protected variables raise exceptions when modified.
